### PR TITLE
path in sourceMappingURL should be shortest possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,23 +213,29 @@ module.exports.write = function write(destPath, options) {
       var base64Map = new Buffer(JSON.stringify(sourceMap)).toString('base64');
       comment = commentFormatter('data:application/json;base64,' + base64Map);
     } else {
+      var source_map_path = path.join(file.base, destPath, file.relative) + '.map';
       // add new source map file to stream
       var sourceMapFile = new File({
         cwd: file.cwd,
         base: file.base,
-        path: path.join(file.base, destPath, file.relative) + '.map',
+        path: source_map_path,
         contents: new Buffer(JSON.stringify(sourceMap))
       });
       this.push(sourceMapFile);
 
-      comment = commentFormatter(unixStylePath(path.join(path.relative(path.dirname(file.path), file.base), destPath, file.relative) + '.map'));
+      var source_map_path_relative = path.relative(path.dirname(file.path), source_map_path);
 
+      var prefix = '';
       if (options.sourceMappingURLPrefix) {
         if (typeof options.sourceMappingURLPrefix === 'function') {
-          options.sourceMappingURLPrefix = options.sourceMappingURLPrefix(file);
+          prefix = options.sourceMappingURLPrefix(file);
+        } else {
+          prefix = options.sourceMappingURLPrefix;
         }
-        comment = comment.replace(/sourceMappingURL=\.*/, 'sourceMappingURL=' + options.sourceMappingURLPrefix);
+        source_map_path_relative = prefix+path.join('/', source_map_path_relative);
       }
+      comment = commentFormatter(unixStylePath(source_map_path_relative));
+
     }
 
     // append source map comment

--- a/test/write.js
+++ b/test/write.js
@@ -36,6 +36,17 @@ function makeFile() {
     return file;
 }
 
+function makeNestedFile(){
+	var file = new File({
+        cwd: __dirname,
+        base: path.join(__dirname, 'assets'),
+        path: path.join(__dirname, 'assets', 'dir1', 'dir2', 'helloworld.js'),
+        contents: new Buffer(sourceContent)
+    });
+    file.sourceMap = makeSourceMap();
+    return file;
+}
+
 function makeStreamFile() {
     var file = new File({
         cwd: __dirname,
@@ -168,6 +179,34 @@ test('write: should write external map files', function(t) {
                         t.ok(data instanceof File, 'should pass a vinyl file through');
                         t.equal(data.path, path.join(__dirname, 'maps/helloworld.js.map'));
                         t.deepEqual(JSON.parse(data.contents), sourceMap, 'should have the file\'s source map as content');
+                    }
+                });
+                t.end();
+            }
+        })
+        .on('error', function() {
+            t.fail('emitted error');
+            t.end();
+        })
+        .write(file);
+});
+
+test('write: should create shortest path to map in file comment', function(t) {
+    var file = makeNestedFile();
+    var pipeline = sourcemaps.write('dir1/maps');
+    var fileCount = 0;
+    var outFiles = [];
+    var sourceMap;
+    pipeline
+        .on('data', function(data) {
+            outFiles.push(data);
+            fileCount++;
+            if (fileCount == 2) {
+                outFiles.reverse().map(function(data) {
+                    if (data.path === path.join(__dirname, 'assets/dir1/dir2/helloworld.js')) {
+                        t.equal(String(data.contents),
+                            sourceContent + '\n//# sourceMappingURL=../maps/dir1/dir2/helloworld.js.map',
+                            'should add a comment referencing the source map file');
                     }
                 });
                 t.end();


### PR DESCRIPTION
Until this point there was some unnecessary directory traversal from output (probably minified) file to map file. By moving around some path.join and path.relative, I removed some additional "../" from the path, and also refactored a bit of code, including removing some hacky regexp replaces.

Tests included.