### PR TITLE
Remove unnecessary paths from `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "coveralls": "^2.11.2"
   },
   "files": [
-    "index.js",
-    "package.json",
-    "README.md",
-    "LICENSE.md"
+    "index.js"
   ]
 }


### PR DESCRIPTION
The readme, license and package.json are included by default.

Ref: https://github.com/seegno-forks/gulp-util/commit/3160b57d8426d6e8214c3bff065e9a1318e4ad02