### PR TITLE
Remove unnecessary `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Source map support for Gulp.js",
   "homepage": "http://github.com/floridoo/gulp-sourcemaps",
   "repository": "git://github.com/floridoo/gulp-sourcemaps.git",
-  "main": "index.js",
   "scripts": {
     "test": "jshint *.js test/*.js && faucet test/*.js",
     "tap": "tape test/*.js",


### PR DESCRIPTION
It is `index.js` by default.
