### PR TITLE
Introduce graceful-fs and strip-bom

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 var through = require('through2');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 var File = require('vinyl');
 var convert = require('convert-source-map');
+var stripBom = require('strip-bom');
 
 var PLUGIN_NAME = 'gulp-sourcemap';
 var urlRegex = /^https?:\/\//;
@@ -54,7 +55,7 @@ module.exports.init = function init(options) {
         sourcePath = path.dirname(mapFile);
 
         try {
-          sourceMap = JSON.parse(fs.readFileSync(mapFile).toString());
+          sourceMap = JSON.parse(stripBom(fs.readFileSync(mapFile, 'utf8')));
         } catch(e) {}
       }
 
@@ -88,7 +89,7 @@ module.exports.init = function init(options) {
               try {
                 if (options.debug)
                   console.log(PLUGIN_NAME + '-init: No source content for "' + source + '". Loading from file.');
-                sourceContent = fs.readFileSync(absPath).toString();
+                sourceContent = stripBom(fs.readFileSync(absPath, 'utf8'));
               } catch (e) {
                 if (options.debug)
                   console.warn(PLUGIN_NAME + '-init: source file not found: ' + absPath);
@@ -180,7 +181,7 @@ module.exports.write = function write(destPath, options) {
           try {
             if (options.debug)
               console.log(PLUGIN_NAME + '-write: No source content for "' + sourceMap.sources[i] + '". Loading from file.');
-            sourceMap.sourcesContent[i] = fs.readFileSync(sourcePath).toString();
+            sourceMap.sourcesContent[i] = stripBom(fs.readFileSync(sourcePath, 'utf8'));
           } catch (e) {
             if (options.debug)
               console.warn(PLUGIN_NAME + '-write: source file not found: ' + sourcePath);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "license": "ISC",
   "dependencies": {
     "convert-source-map": "^0.5.0",
+    "graceful-fs": "^3.0.5",
+    "strip-bom": "^1.0.0",
     "through2": "^0.6.3",
     "vinyl": "^0.4.6"
   },


### PR DESCRIPTION
* [graceful-fs](https://github.com/isaacs/node-graceful-fs) is [more resilient version](https://github.com/isaacs/node-graceful-fs#improvements-over-fs-module) of built-in fs.
* [strip-bom](https://github.com/sindresorhus/strip-bom) removes UTF-8 byte order mark from contents.

Actually, [both of them are used in gulp's file system](https://github.com/wearefractal/vinyl-fs/blob/6d7952973d026246602d59f1358d806463fe508f/lib/src/getContents/bufferFile.js#L3-L4).
