### PR TITLE
Update convert-source-map to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Florian Reiterer <me@florianreiterer.com>",
   "license": "ISC",
   "dependencies": {
-    "convert-source-map": "^0.5.0",
+    "convert-source-map": "^1.0.0",
     "graceful-fs": "^3.0.5",
     "strip-bom": "^1.0.0",
     "through2": "^0.6.3",


### PR DESCRIPTION
Includes some performance improvements. https://github.com/thlorenz/convert-source-map/commit/931a1de96f011b1b46cf36e695284c75facf7542


(try-catch is [one of the optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#2-unsupported-syntax) on V8.)