### PR TITLE
Source path base

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
   });
   ```
 
+- `sourcePathBase`
+
+  Set a base path for each individual source entry.
+
+  Example:
+  ```javascript
+  gulp.task('javascript', function() {
+  var stream = gulp.src('src/**/*.js')
+    .pipe(sourcemaps.init())
+      .pipe(plugin1())
+      .pipe(plugin2())
+    .pipe(sourcemaps.write({includeContent: false, sourcePathBase: '/src'}))
+    .pipe(gulp.dest('dist'));
+  });
+  ```
+
 - `includeContent`
 
   By default the source maps include the source code. Pass `false` to use the original files.

--- a/index.js
+++ b/index.js
@@ -160,6 +160,9 @@ module.exports.write = function write(destPath, options) {
     // fix paths if Windows style paths
     sourceMap.file = unixStylePath(file.relative);
     sourceMap.sources = sourceMap.sources.map(function(filePath) {
+      if (options.sourcePathBase) {
+        filePath = path.join(options.sourcePathBase, filePath);
+      }
       return unixStylePath(filePath);
     });
 


### PR DESCRIPTION
It can be useful to define a base path for each individual entry in the `sources` to avoid paths that lead with `..`, especially since such paths cause Firefox to ignore the embedded source and request the actual file, which can cause an error if it is not there.

For example, this option can be used to change this.

    {"version":3,"sources":["../other.css","test.less"],....}

To this.

    {"version":3,"sources":["other.css","less/test.less"],....}

Without the hassle of the `base` option to `gulp.src`, which adds the full path to the destination path.
