### PR TITLE
Adding an option to strip a path from the source map path before prepending a prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,27 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
 
   This will result in source mapping URL comment like `sourceMappingURL=https://asset-host.example.com/assets/maps/helloworld.js.map`.
 
+- `sourceMappingURLPrefixStripPath`
+
+  Use in conjunction with `sourceMappingURLPrefix` to specify a precise path to strip from the source mapping URL before prepending the prefix.
+  
+  Example:
+  ```javascript
+  gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+      .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+      .pipe(sourcemaps.write('../path/to/maps', {
+        sourceMappingURLPrefix: 'https://asset-host.example.com/assets',
+        sourceMappingURLPrefixStripPath: '../path/to'
+      }))
+      .pipe(gulp.dest('public/scripts'));
+  });
+  ```
+  
+  This will result in source mapping URL comment like `sourceMappingURL=https://asset-host.example.com/assets/maps/helloworld.js.map`.
+
 - `debug`
 
   Set this to `true` to output debug messages (e.g. about missing source content).

--- a/index.js
+++ b/index.js
@@ -230,7 +230,19 @@ module.exports.write = function write(destPath, options) {
         } else {
           sourceMappingURLPrefix = options.sourceMappingURLPrefix;
         }
-        comment = comment.replace(/sourceMappingURL=\.*/, 'sourceMappingURL=' + sourceMappingURLPrefix);
+        
+        var stripPathRegExpFragment;
+        var stripPath = options.sourceMappingURLPrefixStripPath;
+        if (typeof stripPath === 'string') {
+            // escape strip path characters for use in a regular expression
+            stripPathRegExpFragment = stripPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        } else {
+            // default behaviour to remove leading dots
+            stripPathRegExpFragment = '\\.*';
+        }
+        
+        var replacementRegExp = new RegExp('sourceMappingURL=' + stripPathRegExpFragment);
+        comment = comment.replace(replacementRegExp, 'sourceMappingURL=' + sourceMappingURLPrefix);
       }
     }
 

--- a/test/write.js
+++ b/test/write.js
@@ -304,6 +304,40 @@ test('write: should invoke sourceMappingURLPrefix every time', function(t) {
       .write(makeFile());
 });
 
+test('write: should accept a sourceMappingURLPrefixStripPath', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write('../path/to/maps', { 
+        sourceMappingURLPrefix: 'https://asset-host.example.com',
+        sourceMappingURLPrefixStripPath: '../path/to'
+    });
+    pipeline
+      .on('data', function(data) {
+        if (/helloworld\.js$/.test(data.path)) {
+          t.equal(String(data.contents).match(/sourceMappingURL.*$/)[0],
+            'sourceMappingURL=https://asset-host.example.com/maps/helloworld.js.map');
+          t.end();
+        }
+      })
+      .write(file);
+});
+
+test('write: should accept an empty string sourceMappingURLPrefixStripPath', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write('../path/to/maps', { 
+        sourceMappingURLPrefix: 'https://asset-host.example.com/nested/',
+        sourceMappingURLPrefixStripPath: ''
+    });
+    pipeline
+      .on('data', function(data) {
+        if (/helloworld\.js$/.test(data.path)) {
+          t.equal(String(data.contents).match(/sourceMappingURL.*$/)[0],
+            'sourceMappingURL=https://asset-host.example.com/nested/../path/to/maps/helloworld.js.map');
+          t.end();
+        }
+      })
+      .write(file);
+});
+
 test('write: should output an error message if debug option is set and sourceContent is missing', function(t) {
     var file = makeFile();
     file.sourceMap.sources[0] += '.invalid';


### PR DESCRIPTION
When using the sourceMappingURLPrefix the default behaviour to remove leading dots is sometimes not sufficient. For example:

```javascript
sourcemaps.write('../../path/to/maps', {
        sourceMappingURLPrefix: 'https://asset-host.example.com/assets'
})
```

would result in a url of the form `sourceMappingURL=https://asset-host.example.com/assets/../path/to/maps/helloworld.js.map`

This change adds an option to specify a path which is first stripped from the unprefixed path, before then adding the prefix, e.g. 

```javascript
sourcemaps.write('../../path/to/maps', {
        sourceMappingURLPrefix: 'https://asset-host.example.com/assets',
        sourceMappingURLPrefixStripPath: '../../path/to'
})
```

which would result in a url of the form `sourceMappingURL=https://asset-host.example.com/assets/maps/helloworld.js.map`