### PR TITLE
Added write option: omitSourceRootIfUndefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,38 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
   });
   ```
 
+- `omitSourceRootIfUndefined`
+
+  Omits `sourceRoot` value from the generated source map if `includeContent` is set to `true` and `sourceRoot` is set to (or if the `sourceRoot` function returns) `undefined` or `null`. This omission will cause the source root to be seen as the same directory containing the source map.
+
+  Example:
+  ```javascript
+  gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+      .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+      .pipe(sourcemaps.write({omitSourceRootIfUndefined: true}))
+      .pipe(gulp.dest('dist'));
+  });
+  ```
+
+  Example (using a function for `sourceRoot`):
+  ```javascript
+  gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+      .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+      .pipe(sourcemaps.write({
+        sourceRoot: function(file) {
+          return undefined;
+        }
+       }))
+      .pipe(gulp.dest('dist'));
+  });
+  ```
+
 - `sourceMappingURLPrefix`
 
   Specify a prefix to be prepended onto the source map URL when writing external source maps. Relative paths will have their leading dots stripped.

--- a/index.js
+++ b/index.js
@@ -141,6 +141,8 @@ module.exports.write = function write(destPath, options) {
   // set defaults for options if unset
   if (options.includeContent === undefined)
     options.includeContent = true;
+  if (options.omitSourceRootIfUndefined === undefined)
+    options.omitSourceRootIfUndefined = false;
   if (options.addComment === undefined)
     options.addComment = true;
 
@@ -188,7 +190,9 @@ module.exports.write = function write(destPath, options) {
           }
         }
       }
-      sourceMap.sourceRoot = sourceMap.sourceRoot || '/source/';
+      if (!options.omitSourceRootIfUndefined) {
+        sourceMap.sourceRoot = sourceMap.sourceRoot || '/source/';
+      }
     } else {
       delete sourceMap.sourcesContent;
     }

--- a/test/write.js
+++ b/test/write.js
@@ -320,3 +320,31 @@ test('write: should output an error message if debug option is set and sourceCon
         })
         .write(file);
 });
+
+test('write: should not add source root with option omitSourceRootIfUndefined=true and sourceRoot=undefined', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write({
+        sourceRoot: undefined,
+        omitSourceRootIfUndefined: true
+    });
+    pipeline
+        .on('data', function(data) {
+            t.equal(data.sourceMap.sourceRoot, undefined, 'should not have source root');
+            t.end();
+        })
+        .write(file);
+});
+
+test('write: should add source root with option omitSourceRootIfUndefined=true and sourceRoot=*not undefined*', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write({
+        sourceRoot: 'blah',
+        omitSourceRootIfUndefined: true
+    });
+    pipeline
+        .on('data', function(data) {
+            t.equal(data.sourceMap.sourceRoot, 'blah', 'should have source root');
+            t.end();
+        })
+        .write(file);
+});


### PR DESCRIPTION
**New `write` function option added: _omitSourceRootIfUndefined_**

**Description:**

  Omits `sourceRoot` value from the generated source map if `includeContent` is set to `true` and `sourceRoot` is set to (or if the `sourceRoot` function returns) `undefined` or `null`. This omission will cause the source root to be seen as the same directory containing the source map.

  Example:
  ```javascript
  gulp.task('javascript', function() {
    var stream = gulp.src('src/**/*.js')
      .pipe(sourcemaps.init())
        .pipe(plugin1())
        .pipe(plugin2())
      .pipe(sourcemaps.write({omitSourceRootIfUndefined: true}))
      .pipe(gulp.dest('dist'));
  });
  ```

  Example (using a function for `sourceRoot`):
  ```javascript
  gulp.task('javascript', function() {
    var stream = gulp.src('src/**/*.js')
      .pipe(sourcemaps.init())
        .pipe(plugin1())
        .pipe(plugin2())
      .pipe(sourcemaps.write({
        sourceRoot: function(file) {
          return undefined;
        }
       }))
      .pipe(gulp.dest('dist'));
  });
  ```