### PR TITLE
Added `stat` property to improve compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,16 @@ module.exports.write = function write(destPath, options) {
         cwd: file.cwd,
         base: file.base,
         path: path.join(file.base, destPath, file.relative) + '.map',
-        contents: new Buffer(JSON.stringify(sourceMap))
+        contents: new Buffer(JSON.stringify(sourceMap)),
+        stat: {
+          isFile: function () { return true; },
+          isDirectory: function () { return false; },
+          isBlockDevice: function () { return false; },
+          isCharacterDevice: function () { return false; },
+          isSymbolicLink: function () { return false; },
+          isFIFO: function () { return false; },
+          isSocket: function () { return false; }
+        }
       });
       this.push(sourceMapFile);
 


### PR DESCRIPTION
I happened to witness a crash piping `gulp-count` after `gulp-sourcemaps`.
Basically `gulp-count` was trying to access the file's `stat.isFile()` method (not generated by your module), and crashing because of a *null pointer exception*.

What I did was simply add [fs.Stats](https://nodejs.org/api/fs.html#fs_class_fs_stats) methods to your file template.

This could be useful to prevent incompatibilities with other modules.