### PR TITLE
Support webpack:// relative URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var convert = require('convert-source-map');
 var stripBom = require('strip-bom');
 
 var PLUGIN_NAME = 'gulp-sourcemap';
-var urlRegex = /^https?:\/\//;
+var urlRegex = /^(https?|webpack(-[^:]+)?):\/\//;
 
 /**
  * Initialize source mapping chain


### PR DESCRIPTION
webpack and many webpack loaders generate source map paths with a `webpack://` relative URL. This supports passing them through the path resolver just like `https?` URLs.