### PR TITLE
Run tests on the latest stable Node and drop io.js test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - iojs
+  - stable
   - '0.12'
   - '0.10'
 after_script:


### PR DESCRIPTION
[The last version of io.js is positioned as an alpha version of Node v4](https://medium.com/node-js-javascript/4-0-is-the-new-1-0-386597a3436d), so we don’t check if the module works with io.js anymore. We should test it with the latest stable Node instead.
