### PR TITLE
Detect whether a file uses LF or CR+LF and follow the existing style

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 var File = require('vinyl');
 var convert = require('convert-source-map');
 var stripBom = require('strip-bom');
+var detectNewline = require('detect-newline');
 
 var PLUGIN_NAME = 'gulp-sourcemap';
 var urlRegex = /^(https?|webpack(-[^:]+)?):\/\//;
@@ -197,14 +198,19 @@ module.exports.write = function write(destPath, options) {
     }
 
     var extension = file.relative.split('.').pop();
+    var newline = detectNewline(file.contents.toString());
     var commentFormatter;
 
     switch (extension) {
       case 'css':
-        commentFormatter = function(url) { return "\n/*# sourceMappingURL=" + url + " */\n"; };
+        commentFormatter = function(url) {
+          return newline + "/*# sourceMappingURL=" + url + " */" + newline;
+        };
         break;
       case 'js':
-        commentFormatter = function(url) { return "\n//# sourceMappingURL=" + url + "\n"; };
+        commentFormatter = function(url) {
+          return newline + "//# sourceMappingURL=" + url + newline;
+        };
         break;
       default:
         commentFormatter = function(url) { return ""; };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "convert-source-map": "^1.1.1",
+    "detect-newline": "^1.0.3",
     "graceful-fs": "^4.1.2",
     "strip-bom": "^2.0.0",
     "through2": "^2.0.0",

--- a/test/write.js
+++ b/test/write.js
@@ -156,6 +156,26 @@ test('write: should write no comment if not JS or CSS file', function(t) {
         .write(file);
 });
 
+test('write: should detect whether a file uses \\n or \\r\\n and follow the existing style', function(t) {
+    var file = makeFile();
+    file.contents = new Buffer(file.contents.toString().replace(/\n/g, '\r\n'));
+    var pipeline = sourcemaps.write();
+    pipeline
+        .on('data', function(data) {
+            t.ok(data, 'should pass something through');
+            t.equal(String(data.contents),
+                sourceContent.replace(/\n/g, '\r\n') +
+                '\r\n//# sourceMappingURL=' + base64JSON(data.sourceMap) + '\r\n',
+                'should add source map as comment');
+            t.end();
+        })
+        .on('error', function() {
+            t.fail('emitted error');
+            t.end();
+        })
+        .write(file);
+});
+
 test('write: should write external map files', function(t) {
     var file = makeFile();
     var pipeline = sourcemaps.write('../maps');


### PR DESCRIPTION
(Fix #137)

This pull request is an implementation of https://github.com/floridoo/gulp-sourcemaps/issues/137#issuecomment-143625787.

1. Detect whether a file uses `\n` or `\r\n` by using [detect-newline](https://github.com/sindresorhus/detect-newline) module.
2. Use the detected newline when appending Source Map to the bottom of the file

I can add `sourceMapNewline` option or something else to force using specific newline regardless of the detected one, but I didn't add it to this pull request because most of the users prefer the default behavior and don't need to change it. What do you think, @floridoo?
