### PR TITLE
change sourceMap#file to be the shortest relative path to file

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,8 +158,16 @@ module.exports.write = function write(destPath, options) {
     }
 
     var sourceMap = file.sourceMap;
-    // fix paths if Windows style paths
-    sourceMap.file = unixStylePath(file.relative);
+    if (!destPath) {
+      // when inlining source map, file should just be the file name
+      sourceMap.file = path.basename(file.relative);
+    } else {
+      // when not inlining source map, file should be the relative path to the dest file
+      var sourceMapPath = path.join(destPath, path.dirname(file.relative));
+      var relativeToFile = path.relative(sourceMapPath, path.dirname(file.relative));
+      sourceMap.file = unixStylePath(path.join(relativeToFile, path.basename(file.relative)));
+    }
+
     sourceMap.sources = sourceMap.sources.map(function(filePath) {
       return unixStylePath(filePath);
     });

--- a/index.js
+++ b/index.js
@@ -163,8 +163,7 @@ module.exports.write = function write(destPath, options) {
       sourceMap.file = path.basename(file.relative);
     } else {
       // when not inlining source map, file should be the relative path to the dest file
-      var sourceMapPath = path.join(destPath, path.dirname(file.relative));
-      var relativeToFile = path.relative(sourceMapPath, path.dirname(file.relative));
+      var relativeToFile = path.relative(path.join(destPath, path.dirname(file.relative)), path.dirname(file.relative));
       sourceMap.file = unixStylePath(path.join(relativeToFile, path.basename(file.relative)));
     }
 

--- a/test/write.js
+++ b/test/write.js
@@ -219,6 +219,33 @@ test('write: should create shortest path to map in file comment', function(t) {
         .write(file);
 });
 
+test('write: should create shortest path to file in sourceMap#file', function(t) {
+    var file = makeNestedFile();
+    var pipeline = sourcemaps.write('dir1/maps');
+    var fileCount = 0;
+    var outFiles = [];
+    var sourceMap;
+    pipeline
+        .on('data', function(data) {
+            outFiles.push(data);
+            fileCount++;
+            if (fileCount == 2) {
+                outFiles.reverse().map(function(data) {
+                    if (data.path === path.join(__dirname, 'assets/dir1/dir2/helloworld.js')) {
+                        t.equal(data.sourceMap.file, "../../../dir2/helloworld.js",
+                            'sourceMap#file should be referencing the file');
+                    }
+                });
+                t.end();
+            }
+        })
+        .on('error', function() {
+            t.fail('emitted error');
+            t.end();
+        })
+        .write(file);
+});
+
 test('write: should write no comment with option addComment=false', function(t) {
     var file = makeFile();
     var pipeline = sourcemaps.write({addComment: false});


### PR DESCRIPTION
the path was a the relative path, which might be off depending on the dest path, i.e.

i have:

```
src/folderA/folderB/myFile.ts
```

and calling sourcemap to write to ".", and got something like:

```
build/src/folderA/folderB/myFile.js
build/src/folderA/foderB/myFile.js.map
```

the "file" attribute in `myFile.js.map` was originally "folderA/folderB/myFile.js", and it should probably be "myFile.js" instead

let me know if i'm doing anything wrong here though

Thanks!
