### PR TITLE
Add sourcemaps to null files

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports.init = function init(options) {
     /*jshint validthis:true */
 
     // pass through if file is null or already has a source map
-    if (file.isNull() || file.sourceMap) {
+    if (file.sourceMap) {
       this.push(file);
       return callback();
     }
@@ -26,10 +26,10 @@ module.exports.init = function init(options) {
       return callback(new Error(PLUGIN_NAME + '-init: Streaming not supported'));
     }
 
-    var fileContent = file.contents.toString();
+    var fileContent = file.contents && file.contents.toString();
     var sourceMap;
 
-    if (options && options.loadMaps) {
+    if (fileContent && options && options.loadMaps) {
       var sourcePath = ''; //root path for the sources in the map
 
       // Try to read inline source map
@@ -112,7 +112,7 @@ module.exports.init = function init(options) {
         names: [],
         mappings: '',
         sources: [unixStylePath(file.relative)],
-        sourcesContent: [fileContent]
+        sourcesContent: fileContent ? [fileContent] : []
       };
     }
 

--- a/test/init.js
+++ b/test/init.js
@@ -19,6 +19,14 @@ function makeFile() {
     });
 }
 
+function makeNullFile() {
+    return new File({
+        cwd: __dirname,
+        base: path.join(__dirname, 'assets'),
+        path: path.join(__dirname, 'assets', 'helloworld.js')
+    });
+}
+
 function makeStreamFile() {
     return new File({
         cwd: __dirname,
@@ -37,14 +45,14 @@ function makeFileWithInlineSourceMap() {
     });
 }
 
-test('init: should pass through when file is null', function(t) {
-    var file = new File();
+test('init: should add a sourcemap when file is null', function(t) {
+    var file = makeNullFile();
     var pipeline = sourcemaps.init();
     pipeline
         .on('data', function(data) {
             t.ok(data, 'should pass something through');
             t.ok(data instanceof File, 'should pass a vinyl file through');
-            t.ok(!data.sourceMap, 'should not add a source map object');
+            t.ok(data.sourceMap, 'should add a source map object');
             t.deepEqual(data, file, 'should not change file');
             t.end();
         })


### PR DESCRIPTION
Currently, `sourcemaps.init` passes null files through without adding sourcemaps to them. This means that a plugin further down the line that takes null files has no way of telling if it's supposed to output a sourcemap.

It may seem like a plugin that doesn't take buffers shouldn't be transforming code and therefore wouldn't need a sourcemap, but [gulp-rollup](https://github.com/mcasimir/gulp-rollup) uses the Vinyl input stream to mark out paths instead of to take in code directly, since one input path actually corresponds to a lot of interdependent module files.

Of course, null files wouldn't work with `options.loadMaps`. I currently have it set to simply ignore that option for null files, but maybe it should emit an error or something instead.