### PR TITLE
feature: add support for large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ gulp.task('javascript', function() {
 });
 ```
 
+#### Handle large files
+
+To handle large files, pass the option `largeFile: true` to `sourcemaps.init()`.
+
+Example:
+```javascript
+var gulp = require('gulp');
+var plugin1 = require('gulp-plugin1');
+var plugin2 = require('gulp-plugin2');
+var sourcemaps = require('gulp-sourcemaps');
+
+gulp.task('javascript', function() {
+  gulp.src('src/**/*.js')
+    .pipe(sourcemaps.init({largeFile: true}))
+      .pipe(plugin1())
+      .pipe(plugin2())
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('dist'));
+});
+```
+
 #### Handle source files from different directories
 
 Use the `base` option on `gulp.src` to make sure all files are relative to a common base directory.

--- a/index.js
+++ b/index.js
@@ -41,12 +41,14 @@ module.exports.init = function init(options) {
       var sourcePath = ''; //root path for the sources in the map
 
       // Try to read inline source map
-      sourceMap = convert.fromSource(fileContent);
+      sourceMap = convert.fromSource(fileContent, options.largeFile);
       if (sourceMap) {
         sourceMap = sourceMap.toObject();
         // sources in map are relative to the source file
         sourcePath = path.dirname(file.path);
-        fileContent = convert.removeComments(fileContent);
+        if (!options.largeFile) {
+          fileContent = convert.removeComments(fileContent);
+        }
       } else {
         // look for source map comment referencing a source map file
         var mapComment = convert.mapFileCommentRegex.exec(fileContent);


### PR DESCRIPTION
- expose option to handle large files via options.largeFiles
- add conditional to not remove comments from large files
- update readme with largeFile info

This PR enables control over the largeFile option in the convert-from-source package which is needed in some cases to fix #73 aka maximum call stack size exceeded.