### PR TITLE
upgrading dependencies to support ES6 better

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,22 +20,22 @@
   "author": "Florian Reiterer <me@florianreiterer.com>",
   "license": "ISC",
   "dependencies": {
-    "acorn": "^2.6.4",
-    "convert-source-map": "^1.1.1",
+    "acorn": "^4.0.1",
+    "convert-source-map": "^1.3.0",
     "css": "^2.2.1",
-    "detect-newline": "^1.0.3",
-    "graceful-fs": "^4.1.2",
-    "source-map": "^0.5.3",
-    "strip-bom": "^2.0.0",
-    "through2": "^2.0.0",
-    "vinyl": "^1.0.0"
+    "detect-newline": "^2.1.0",
+    "graceful-fs": "^4.1.6",
+    "source-map": "^0.5.6",
+    "strip-bom": "^3.0.0",
+    "through2": "^2.0.1",
+    "vinyl": "^1.2.0"
   },
   "devDependencies": {
-    "jshint": "^2.8.0",
-    "tape": "^4.2.0",
-    "istanbul": "^0.3.21",
+    "jshint": "^2.9.3",
+    "tape": "^4.6.0",
+    "istanbul": "^0.4.5",
     "faucet": "0.0.1",
-    "coveralls": "^2.11.4"
+    "coveralls": "^2.11.12"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
ran a ncu update on the package.json file to bring it inline with latest version of libraries for issue

https://github.com/floridoo/gulp-sourcemaps/issues/223