### PR TITLE
gracefully fail newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ module.exports.write = function write(destPath, options) {
     }
 
     var extension = file.relative.split('.').pop();
-    var newline = detectNewline(file.contents.toString());
+    var newline = detectNewline.graceful(file.contents.toString());
     var commentFormatter;
 
     switch (extension) {


### PR DESCRIPTION
without the `.graceful` it defaults to `null`. `.graceful` defaults to `'\n'`, which is much more widely used as a new line character than `null`